### PR TITLE
Fix auto-publisher: articles not publishing after scheduled date

### DIFF
--- a/server/integrations/airtable.ts
+++ b/server/integrations/airtable.ts
@@ -758,17 +758,8 @@ export async function syncArticlesFromAirtable(
       if (!finishedFlag || republishedFlag) {
         articleData.status = "draft";
 
-        // If scheduled date is in the past, clear it to prevent auto-publish
-        if (articleData.Scheduled) {
-          const scheduledDate = new Date(articleData.Scheduled);
-          const now = new Date();
-          if (!isNaN(scheduledDate.getTime()) && scheduledDate < now) {
-            console.log(`Unpublishing article ${fields.Name} (ID: ${record.id}): Clearing past scheduled date to prevent auto-republish loop`);
-            (articleData as any).Scheduled = null;
-          }
-        }
-
-        // For republished items, also clear publishedAt to avoid showing as published
+        // For republished items, clear publishedAt to avoid showing as published
+        // Do NOT clear Scheduled for regular drafts — the auto-publisher needs it to publish on time
         if (republishedFlag) {
           articleData.publishedAt = null;
         }

--- a/server/integrations/airtable.ts
+++ b/server/integrations/airtable.ts
@@ -1,5 +1,6 @@
 import { Express, Request, Response } from "express";
 import { storage } from "../storage";
+import { isRecentlyPublished } from "../publishState";
 import { Article, InsertArticle, InsertTeamMember, InsertCarouselQuote } from "@shared/schema";
 import { upload } from "../utils/fileUpload";
 import {
@@ -754,14 +755,20 @@ export async function syncArticlesFromAirtable(
         source: "airtable"
       };
 
-      // Force status to "draft" if Finished is false or Republished is checked
+      // Force status to "draft" if Finished is false or Republished is checked.
+      // Skip the revert if the scheduler just published this record and hasn't finished
+      // writing Finished=true back to Airtable yet (publish/sync race window).
       if (!finishedFlag || republishedFlag) {
-        articleData.status = "draft";
+        if (isRecentlyPublished(record.id)) {
+          console.log(`Skipping draft-revert for ${fields.Name} (ID: ${record.id}): recently published, Airtable write still in flight`);
+        } else {
+          articleData.status = "draft";
 
-        // For republished items, clear publishedAt to avoid showing as published
-        // Do NOT clear Scheduled for regular drafts — the auto-publisher needs it to publish on time
-        if (republishedFlag) {
-          articleData.publishedAt = null;
+          // For republished items, clear publishedAt to avoid showing as published
+          // Do NOT clear Scheduled for regular drafts — the auto-publisher needs it to publish on time
+          if (republishedFlag) {
+            articleData.publishedAt = null;
+          }
         }
       }
 

--- a/server/publishState.ts
+++ b/server/publishState.ts
@@ -1,0 +1,25 @@
+/**
+ * In-process TTL guard against the publish/sync race condition.
+ *
+ * Window being closed: after the scheduler writes status=published to the local
+ * DB but before it finishes PATCHing Airtable's Finished field, an Airtable sync
+ * could read Finished=false and revert the article to draft.
+ *
+ * When the scheduler successfully pushes Finished=true for an article, it calls
+ * markRecentlyPublished(externalId). syncArticlesFromAirtable then skips any
+ * draft-revert for records whose externalId appears within the TTL window.
+ */
+
+const RECENTLY_PUBLISHED_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+const recentlyPublishedAt = new Map<string, number>(); // externalId → Date.now()
+
+export function markRecentlyPublished(externalId: string): void {
+    recentlyPublishedAt.set(externalId, Date.now());
+}
+
+export function isRecentlyPublished(externalId: string): boolean {
+    const ts = recentlyPublishedAt.get(externalId);
+    if (ts === undefined) return false;
+    return Date.now() - ts < RECENTLY_PUBLISHED_TTL_MS;
+}

--- a/server/scheduler.ts
+++ b/server/scheduler.ts
@@ -1,6 +1,7 @@
 import { storage } from "./storage";
 import { log } from "./vite";
 import { postArticleToInstagram } from "./integrations/instagram";
+import { markRecentlyPublished } from "./publishState";
 import type { Article } from "@shared/schema";
 
 let isRunning = false;
@@ -103,10 +104,12 @@ async function ensureArticleOnAirtable(article: Article): Promise<Article> {
 
             if (updated) {
                 log(`Article ${article.id} pushed to Airtable with id ${airtableId}`, "scheduler");
+                if (fields.Finished) markRecentlyPublished(airtableId);
                 return updated as Article;
             }
         } else {
             log(`Article ${article.id} updated in Airtable with id ${article.externalId}`, "scheduler");
+            if (fields.Finished) markRecentlyPublished(article.externalId);
             return article;
         }
     } catch (err) {
@@ -224,8 +227,13 @@ async function checkAndPublishDueArticles(): Promise<void> {
             if (a.republished) return false;
 
             // Skip if the article was previously published (publishedAt is set).
-            // Once an article has been published, only explicit user action should republish it —
-            // the scheduler should not auto-republish after a draft revert.
+            // This guards locally-edited articles: if a published article is reverted
+            // to draft via the UI, publishedAt remains set and the scheduler leaves it alone.
+            // Note: this guard does NOT apply to Airtable-synced drafts — syncArticlesFromAirtable
+            // sets publishedAt to null for all non-finished records (publishedAtValue is null when
+            // finishedFlag is false), so a previously-published article that re-enters via sync
+            // will have publishedAt === null here. The republished flag is the mechanism that
+            // protects those articles from accidental auto-publish.
             if (a.publishedAt) return false;
 
             const when = parseScheduledDate(a);

--- a/server/scheduler.ts
+++ b/server/scheduler.ts
@@ -215,18 +215,22 @@ async function checkAndPublishDueArticles(): Promise<void> {
         if (candidates.length === 0) return;
 
         const now = new Date();
-        // Limit auto-publish to articles scheduled within the last 2 hours
-        // This prevents old drafts from being accidentally republished
-        // while allowing for a small window of system delay catch-up.
-        const cutoffTime = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+        // Limit auto-publish to articles scheduled within the last 24 hours
+        // to catch up after downtime while avoiding re-publishing old drafts.
+        const cutoffTime = new Date(now.getTime() - 24 * 60 * 60 * 1000);
 
         const due = candidates.filter(a => {
-        // Skip if the Republished flag is set; these are explicitly held as drafts
-        if (a.republished) return false;
+            // Skip if the Republished flag is set; these are explicitly held as drafts
+            if (a.republished) return false;
+
+            // Skip if the article was previously published (publishedAt is set).
+            // Once an article has been published, only explicit user action should republish it —
+            // the scheduler should not auto-republish after a draft revert.
+            if (a.publishedAt) return false;
 
             const when = parseScheduledDate(a);
             // Rule 1: Scheduled time must be in the past (<= now)
-            // Rule 2: Scheduled time must be recent (>= cutoffTime)
+            // Rule 2: Scheduled time must be recent (<= 24 hours ago)
             return when !== null && when <= now && when >= cutoffTime;
         });
 
@@ -238,6 +242,9 @@ async function checkAndPublishDueArticles(): Promise<void> {
                 log(`Auto-publish candidate ${article.id}: ${article.title}`, "scheduler");
                 const ensured = await ensureArticleOnAirtable(article);
                 await publishArticle(ensured);
+                // Push Finished=true back to Airtable now that the article is published.
+                // Without this, the next Airtable sync would see Finished=false and revert to draft.
+                await ensureArticleOnAirtable({ ...ensured, status: "published", finished: true });
             } catch (err) {
                 log(`Error auto-publishing article ${article.id}: ${String(err)}`, "scheduler");
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Drafts no longer lose scheduled publication dates.
  * Prevented already-published items from being auto-published again.
  * Avoided race conditions that could revert freshly published articles back to draft.

* **Improvements**
  * Extended auto-publish eligibility window from 2 to 24 hours.
  * Improved sync behavior with the external CMS to reliably mark items as published and finished.
  * Added a short-lived guard to track recently published items and reduce publish/sync races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->