### PR TITLE
Make /api/health prove the database works

### DIFF
--- a/.github/workflows-for-website-repo/cms-deployed.yml
+++ b/.github/workflows-for-website-repo/cms-deployed.yml
@@ -66,19 +66,42 @@ jobs:
       - name: Verify the Express layer and webhook router are mounted
         run: curl -fsS --max-time 10 "$SITE/api/webhooks/health"
 
-      # POST /api/cache/refresh has no auth on main today, so the header is
-      # added only when the secret exists. Once PR #16 (chore/code-review-refactor)
-      # merges, requireAdmin applies: without ADMIN_TOKEN this returns 503 in
-      # production, and with a wrong one, 401.
+      # POST /api/cache/refresh is gated by requireAdmin (server/middleware/auth.ts).
+      # ADMIN_TOKEN is a shared secret you choose, and it has to exist in TWO
+      # places with the same value: as a variable on this site's Railway service
+      # (what the server compares against) and as a GitHub secret on this repo
+      # (what this step presents). The gate exists because each refresh fans out
+      # to several full-table Airtable scans and bypasses the refresh throttle,
+      # so an open endpoint is a rate-limit exhaustion vector.
       - name: Force a full cache refresh
         env:
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
-          args=(-fsS --max-time 60 -X POST "$SITE/api/cache/refresh"
+          args=(-sS --max-time 60 -o /tmp/refresh.out -w '%{http_code}'
+                -X POST "$SITE/api/cache/refresh"
                 -H 'content-type: application/json' -d '{}')
           if [ -n "$ADMIN_TOKEN" ]; then
             args+=(-H "Authorization: Bearer $ADMIN_TOKEN")
           else
-            echo "::warning::ADMIN_TOKEN is not set - sending the refresh unauthenticated. This works only while /api/cache/refresh is open."
+            echo "::warning::ADMIN_TOKEN is not set as a GitHub secret on this repo; the refresh will be rejected in production."
           fi
-          curl "${args[@]}"
+
+          # Deliberately not `curl -f`: that turns every rejection into the same
+          # opaque "exit code 22", and 503 and 401 have completely different
+          # fixes. Read the status and say which.
+          code="$(curl "${args[@]}")"
+          body="$(head -c 300 /tmp/refresh.out 2>/dev/null || true)"
+
+          case "$code" in
+            2*)
+              echo "- cache refresh: \`$code\`" >> "$GITHUB_STEP_SUMMARY" ;;
+            503)
+              echo "::error::503 from /api/cache/refresh: ADMIN_TOKEN is not set on the SITE's Railway service, so requireAdmin is failing closed. Set it there (Variables tab), matching the GitHub secret of the same name."
+              exit 1 ;;
+            401)
+              echo "::error::401 from /api/cache/refresh: ADMIN_TOKEN is set on the Railway service but does not match the GitHub secret on this repo. They must be the same string."
+              exit 1 ;;
+            *)
+              echo "::error::Unexpected $code from /api/cache/refresh: $body"
+              exit 1 ;;
+          esac

--- a/server/routes/system.ts
+++ b/server/routes/system.ts
@@ -9,6 +9,7 @@ import { isAuthenticated } from '../middleware/auth';
 import { getMigrationProgress } from '../utils/migrationProgress';
 import { getAllApiStatuses } from '../api-status';
 import { env } from '../lib/env';
+import { pgPool } from '../db';
 
 /** Prevents a proxy or browser from serving a stale snapshot of live status. */
 function noStore(res: Parameters<Parameters<Router['get']>[1]>[1]) {
@@ -17,28 +18,74 @@ function noStore(res: Parameters<Parameters<Router['get']>[1]>[1]) {
   res.setHeader('Expires', '0');
 }
 
+/** How long the health probe waits for the database before calling it unreachable. */
+const DB_PROBE_TIMEOUT_MS = 3_000;
+
+/**
+ * Runs the cheapest possible query to prove the pool can actually serve one.
+ *
+ * Bounded by its own timer as well as the pool's connectionTimeoutMillis: that
+ * setting covers acquiring a connection, but a server that accepts the socket
+ * and then stops responding would leave the query outstanding and hang the
+ * probe — which Railway would eventually score as a failed healthcheck anyway,
+ * just far more slowly and with nothing in the log explaining why.
+ */
+async function probeDatabase(): Promise<boolean> {
+  try {
+    await Promise.race([
+      pgPool.query('select 1'),
+      new Promise((_resolve, reject) =>
+        setTimeout(() => reject(new Error(`timed out after ${DB_PROBE_TIMEOUT_MS}ms`)),
+          DB_PROBE_TIMEOUT_MS).unref(),
+      ),
+    ]);
+    return true;
+  } catch (error) {
+    // Logged rather than returned: this route is public and unauthenticated, so
+    // the response says only whether the database answered. The 503 is the
+    // signal; this line is where an operator finds out why.
+    console.error(
+      `[health] database probe failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
+}
+
 /** The platform health probe is the only route that must answer without a session. */
 export function publicSystemRouter(): Router {
   const router = Router();
 
-  router.get('/api/health', (_req, res) => {
-    res.json({
-      status: 'ok',
+  /**
+   * Reports 503 when the database is unreachable, which makes railway.toml's
+   * healthcheckPath refuse to mark such a container healthy.
+   *
+   * It used to report `database: Boolean(env.databaseUrl)` — true whenever the
+   * variable was merely *set*. That is how the deploy of e592859 went green
+   * while `rejectUnauthorized: true` was rejecting Railway's self-signed
+   * certificate on every single query: the container answered 200, Railway
+   * marked the rollout healthy, the post-deploy smoke test passed, and login
+   * had been down the entire time. A probe that cannot fail is not a probe.
+   */
+  router.get('/api/health', async (_req, res) => {
+    const database = await probeDatabase();
+
+    res.status(database ? 200 : 503).json({
+      status: database ? 'ok' : 'degraded',
       timestamp: new Date().toISOString(),
       environment: env.isProduction ? 'production' : 'development',
       /**
        * The commit this container was built from.
        *
        * This is the only field that distinguishes a new deployment from the one
-       * it replaced — `status`, `database` and `sessionSecret` all stay true
-       * against the previous build — so the post-deploy smoke test in
-       * .github/workflows/post-deploy.yml asserts on it to prove the rollout
-       * actually landed. Railway injects RAILWAY_GIT_COMMIT_SHA automatically
-       * for GitHub-connected services; null elsewhere (local, tests).
+       * it replaced — the others stay identical against the previous build — so
+       * the post-deploy smoke test in .github/workflows/post-deploy.yml asserts
+       * on it to prove the rollout actually landed. Railway injects
+       * RAILWAY_GIT_COMMIT_SHA automatically for GitHub-connected services;
+       * null elsewhere (local, tests).
        */
       commit: process.env.RAILWAY_GIT_COMMIT_SHA ?? null,
       // Booleans only — never echo the values themselves.
-      database: Boolean(env.databaseUrl),
+      database,
       sessionSecret: Boolean(process.env.SESSION_SECRET),
     });
   });


### PR DESCRIPTION
## Why

The deploy of `e592859` went green while production was entirely broken. Strict TLS (`rejectUnauthorized: true` with no CA) was rejecting Railway's self-signed certificate on **every** query — login, `/api/user` and the publish scheduler were all down — yet:

- the container answered `200` on `/api/health`
- Railway marked the rollout healthy
- `post-deploy.yml` reported success

Because `/api/health` reported `database: Boolean(env.databaseUrl)`, which only proves the *variable is set*. A probe that cannot fail is not a probe.

## What changed

**`server/routes/system.ts`** — the probe now runs `select 1` and returns `503` / `status: "degraded"` when it fails. Two gates start working as a result: `railway.toml`'s `healthcheckPath` refuses to mark such a container healthy, and `post-deploy.yml`'s assertion on `status == "ok"` fails instead of passing.

Bounded by its own 3s timer *as well as* the pool's `connectionTimeoutMillis` — that setting covers acquiring a connection, but a server that accepts the socket then stops answering would hang the probe.

The reason goes to the **log, not the response**. This route is public and unauthenticated, so the body says only whether the database answered; the 503 is the signal.

Verified against an unreachable database:

```
HTTP=503
{"status":"degraded","database":false,...}
[health] database probe failed: connect ECONNREFUSED 127.0.0.1:59999
```

The happy path is covered by this PR's own `e2e` job — its "Wait for /api/health" step uses `curl -fsS` against a real Postgres, so a broken probe fails CI.

**`.github/workflows-for-website-repo/cms-deployed.yml`** — the comment claimed `/api/cache/refresh` was unauthenticated pending PR #16 on the website repo. That merged, so `requireAdmin` applies and the step failed with a bare `curl: (22)`. Dropped `curl -f`, which collapses every rejection into one opaque exit code, and now names the fix: **503** = `ADMIN_TOKEN` unset on the site's Railway service, **401** = it doesn't match the GitHub secret.

## Trade-off worth knowing

A genuine database outage will now make Railway refuse to complete a deploy, and can roll one back. That is the deliberate choice — it is what would have stopped this incident at the gate rather than after it — but it does mean a DB blip can block an otherwise-good deploy.

## Note

`cms-deployed.yml` lives here only as a copy to hand over; the live one is in `pinkytoedev/PinkyToeWebsite`. Merging this does **not** update it there — that file needs copying across separately.